### PR TITLE
A few improvements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,5 @@ export function print(wrapper: Wrapper): string {
 export function wrap(value: string): Wrapper {
   return { [RAW]: value };
 }
+
+export default wrap;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-const RAW = Symbol('jest-snapshot-serializer-raw');
+const RAW = Symbol.for('jest-snapshot-serializer-raw');
 
 export interface Wrapper {
   [RAW]: string;


### PR DESCRIPTION
* I made `wrap()` the default export so you can both `import { wrap } from 'jest-snapshot-serializer-raw'` and `import wrap from 'jest-snapshot-serializer-raw'`.
* I switched the `Symbol` creation to use `Symbol.for` to prevent failure if the module is instantiated multiple times.