### PR TITLE
fix: trim string before print

### DIFF
--- a/src/always.ts
+++ b/src/always.ts
@@ -3,5 +3,5 @@ export function test(value: any): value is string {
 }
 
 export function print(value: string): string {
-  return value;
+  return value.trim();
 }


### PR DESCRIPTION
`kcd-scripts` added `jest-snapshot-serializer-raw/always` as a default serializer in [`v10.0.0`](https://github.com/kentcdodds/kcd-scripts/releases/tag/v10.0.0).

When updating `gatsby-remark-embedder` and removing my own version of the serializer (as can be seen in https://github.com/MichaelDeBoey/gatsby-remark-embedder/pull/183), my tests failed because there now isn't any trim happening anymore.

This causes all my tests to need to have an extra empty line at the end of each snapshot, which could be removed by doing a trim.